### PR TITLE
Ignore major node-fetch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,9 @@ updates:
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
     directory: "/"
+    ignore:
+      - dependency-name: "node-fetch"
+        update-types: ["version-update:semver-major"]
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
This PR is to get dependabot to ignore major node-fetch versions as node-fetch v3 doesn't support CommonJS and v2 will continue to receive updates as stated here: https://www.npmjs.com/package/node-fetch